### PR TITLE
Throw error if uploading is failed

### DIFF
--- a/lib/fastlane/plugin/nexus_raw_upload/actions/raw_upload_action.rb
+++ b/lib/fastlane/plugin/nexus_raw_upload/actions/raw_upload_action.rb
@@ -6,15 +6,18 @@ module Fastlane
   module Actions
     class RawUploadAction < Action
       def self.run(params)
-        command = []
-        command << "curl"
-        command << verbose(params)
-        command << "--fail"
-        command += ssl_options(params)
-        command += upload_options(params)
-        command << upload_url(params)
+        args = []
+        args << "curl"
+        args << verbose(params)
+        args << "--fail"
+        args += ssl_options(params)
+        args += upload_options(params)
+        args << upload_url(params)
+        command = args.join(' ')
 
-        Fastlane::Actions.sh(command.join(' '), log: params[:verbose])
+        success = true
+        Fastlane::Actions.sh(command, log: params[:verbose], error_callback: -> (result) { success = false })
+        UI.user_error "raw_upload failed with status #{$?.exitstatus}: #{command}" unless success
       end
 
       def self.description


### PR DESCRIPTION
If uploading fails, `user_error` will be shown and Fastlane's process will be stopped.